### PR TITLE
Feat/#93: Add additional endpoint for auth admins 👷

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from "./auth/auth.module";
 import { BookModule } from "./book/book.module";
 import { AuthorModule } from "./author/author.module";
 import { CategoryModule } from "./category/category.module";
+import { ReviewModule } from "./review/review.module";
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { CategoryModule } from "./category/category.module";
     BookModule,
     AuthorModule,
     CategoryModule,
+    ReviewModule,
   ],
   controllers: [],
   providers: [],

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -32,6 +32,16 @@ export class AuthController {
     return this.authService.loginWithEmailAndPassword(authDto);
   }
 
+  @ApiBody({ type: AuthDto })
+  @ApiOkResponse({ description: "The record has been successfully returned." })
+  @ApiBadRequestResponse({ description: "The record has failed validation." })
+  @ApiUnauthorizedResponse({ description: "Unauthorized action, only for admins." })
+  @ApiForbiddenResponse({ description: "Forbidden!" })
+  @Post("signin-admin")
+  public async adminLogin(@Body() authDto: AuthDto) {
+    return this.authService.adminLogin(authDto);
+  }
+
   @ApiBody({ type: CreateUserDto })
   @ApiCreatedResponse({ description: "The record has been successfully created." })
   @ApiBadRequestResponse({ description: "The record has failed validation." })

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -36,7 +36,7 @@ export class AuthController {
   @ApiOkResponse({ description: "The record has been successfully returned." })
   @ApiBadRequestResponse({ description: "The record has failed validation." })
   @ApiUnauthorizedResponse({ description: "Unauthorized action, only for admins." })
-  @ApiForbiddenResponse({ description: "Forbidden!" })
+  @ApiForbiddenResponse({ description: "Forbidden, only for admins!" })
   @Post("signin-admin")
   public async adminLogin(@Body() authDto: AuthDto) {
     return this.authService.adminLogin(authDto);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -22,9 +22,15 @@ export class AuthService {
     private readonly configService: ConfigService
   ) {}
 
-  private async storeUserRecordWithHash(email: string, hash: string, fullName: string) {
+  private async storeUserRecordWithHash(
+    email: string,
+    hash: string,
+    fullName: string,
+    username: string
+  ) {
     const userRecord = await this.userRepository.create({
       email,
+      username,
       password: hash,
       fullName,
       role: Role.READER,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -137,6 +137,7 @@ export class AuthService {
     email,
     password: p,
     fullName,
+    username,
   }: CreateUserDto) {
     const isEmailTaken = await this.userRepository.findOne({ email });
 
@@ -149,7 +150,8 @@ export class AuthService {
     const userRecord = await this.storeUserRecordWithHash(
       email,
       hashedPassword,
-      fullName
+      fullName,
+      username
     );
 
     return {

--- a/src/auth/dto/create-user.dto.ts
+++ b/src/auth/dto/create-user.dto.ts
@@ -22,4 +22,10 @@ export class CreateUserDto {
   @MinLength(4, { message: "Name must be at least 4 characters!" })
   @MaxLength(26, { message: "Name must be at most 26 characters!" })
   fullName!: string;
+
+  @ApiProperty({ type: "String", description: "User name" })
+  @IsDefined({ message: "Username must be provided!" })
+  @MinLength(3, { message: "Usernames must have at least 3 characters!" })
+  @MaxLength(12, { message: "Usernames must be at most 12 characters!" })
+  username!: string;
 }

--- a/src/review/dto/create-review.dto.ts
+++ b/src/review/dto/create-review.dto.ts
@@ -4,7 +4,7 @@ import { IsDefined, IsOptional, IsString, MinLength, IsPositive } from "class-va
 export class CreateReviewDto {
   @ApiProperty({ description: "Reviewer comment on book", required: true })
   @IsString({ message: "Comment must be of type string!" })
-  @MinLength(100, { message: "Name must have at least 100 characters!" })
+  @MinLength(100, { message: "Comment must have at least 100 characters!" })
   //Todo?: Add @MaxLength
   @IsDefined({ message: "Comment must not be empty!" })
   comment!: string;
@@ -13,11 +13,4 @@ export class CreateReviewDto {
   @IsOptional()
   @IsPositive({ message: "Review must be a positive number!" })
   rating?: number;
-
-  @ApiProperty({ description: "Reviewer ID", required: true })
-  @IsOptional()
-  user?: string;
-
-  @ApiProperty({ description: "Reviewer type", required: true })
-  userType?: string;
 }

--- a/src/review/dto/create-review.dto.ts
+++ b/src/review/dto/create-review.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsDefined, IsOptional, IsString, MinLength, IsPositive } from "class-validator";
+
+export class CreateReviewDto {
+  @ApiProperty({ description: "Reviewer comment on book", required: true })
+  @IsString({ message: "Comment must be of type string!" })
+  @MinLength(100, { message: "Name must have at least 100 characters!" })
+  //Todo?: Add @MaxLength
+  @IsDefined({ message: "Comment must not be empty!" })
+  comment!: string;
+
+  @ApiProperty({ description: "Reviewer rating on book", required: false, default: 0 })
+  @IsOptional()
+  @IsPositive({ message: "Review must be a positive number!" })
+  rating?: number;
+
+  @ApiProperty({ description: "Reviewer ID", required: true })
+  @IsOptional()
+  user?: string;
+
+  @ApiProperty({ description: "Reviewer type", required: true })
+  userType?: string;
+}

--- a/src/review/dto/update-review.dto.ts
+++ b/src/review/dto/update-review.dto.ts
@@ -1,11 +1,5 @@
-import { ApiProperty, PartialType } from "@nestjs/swagger";
+import { PartialType } from "@nestjs/swagger";
 
 import { CreateReviewDto } from "./create-review.dto";
-import { IsOptional, IsString } from "class-validator";
 
-export class UpdateReviewDto extends PartialType(CreateReviewDto) {
-  @ApiProperty({ description: "Reviewer found it useful ", required: false })
-  @IsString({ message: "Review must be of type string(ObjectId)!" })
-  @IsOptional()
-  helpful?: string[];
-}
+export class UpdateReviewDto extends PartialType(CreateReviewDto) {}

--- a/src/review/dto/update-review.dto.ts
+++ b/src/review/dto/update-review.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty, PartialType } from "@nestjs/swagger";
+
+import { CreateReviewDto } from "./create-review.dto";
+import { IsOptional, IsString } from "class-validator";
+
+export class UpdateReviewDto extends PartialType(CreateReviewDto) {
+  @ApiProperty({ description: "Reviewer found it useful ", required: false })
+  @IsString({ message: "Review must be of type string(ObjectId)!" })
+  @IsOptional()
+  helpful?: string[];
+
+  @ApiProperty({ description: "Review total count", required: false })
+  @IsString({ message: "Review must be of type String!" })
+  @IsOptional()
+  countHelpful?: string;
+}

--- a/src/review/dto/update-review.dto.ts
+++ b/src/review/dto/update-review.dto.ts
@@ -8,9 +8,4 @@ export class UpdateReviewDto extends PartialType(CreateReviewDto) {
   @IsString({ message: "Review must be of type string(ObjectId)!" })
   @IsOptional()
   helpful?: string[];
-
-  @ApiProperty({ description: "Review total count", required: false })
-  @IsString({ message: "Review must be of type String!" })
-  @IsOptional()
-  countHelpful?: string;
 }

--- a/src/review/models/review.entity.ts
+++ b/src/review/models/review.entity.ts
@@ -1,0 +1,30 @@
+import { BaseEntitySchema } from "@/db/base.schema";
+import { Document, SchemaTypes } from "mongoose";
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+
+import { Role, RoleType } from "../role.enum";
+
+export type ReviewDocument = ReviewEntity & Document;
+
+@Schema({ collection: "reviews" })
+export class ReviewEntity extends BaseEntitySchema {
+  @Prop({ required: true, unique: true, trim: true, minlength: 54, maxlength: 4096 })
+  comment!: string;
+
+  @Prop({ required: true, trim: true })
+  rating!: number;
+
+  @Prop({ required: true, type: SchemaTypes.ObjectId })
+  user!: string;
+
+  @Prop({ required: true, type: SchemaTypes.ObjectId })
+  helpful!: string[];
+
+  @Prop({ required: true })
+  countHelpFul!: number;
+
+  @Prop({ required: true, enum: Object.values(Role), default: Role.READER })
+  type!: RoleType;
+}
+
+export const ReviewEntitySchema = SchemaFactory.createForClass(ReviewEntity);

--- a/src/review/models/review.entity.ts
+++ b/src/review/models/review.entity.ts
@@ -1,14 +1,13 @@
 import { BaseEntitySchema } from "@/db/base.schema";
 import { Document, SchemaTypes } from "mongoose";
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
-
-import { Role, RoleType } from "../role.enum";
+import { Role, RoleType } from "@/auth/role.enum";
 
 export type ReviewDocument = ReviewEntity & Document;
 
 @Schema({ collection: "reviews" })
 export class ReviewEntity extends BaseEntitySchema {
-  @Prop({ required: true, unique: true, trim: true, minlength: 54, maxlength: 4096 })
+  @Prop({ required: true, trim: true, minlength: 100, maxlength: 4000 })
   comment!: string;
 
   @Prop({ required: true, trim: true })
@@ -17,7 +16,7 @@ export class ReviewEntity extends BaseEntitySchema {
   @Prop({ required: true, type: SchemaTypes.ObjectId })
   user!: string;
 
-  @Prop({ required: true, type: SchemaTypes.ObjectId })
+  @Prop({ required: true, type: SchemaTypes.ObjectId, default: 0 })
   helpful!: string[];
 
   @Prop({ required: true })

--- a/src/review/models/review.entity.ts
+++ b/src/review/models/review.entity.ts
@@ -16,10 +16,10 @@ export class ReviewEntity extends BaseEntitySchema {
   @Prop({ required: true, type: SchemaTypes.ObjectId })
   user!: string;
 
-  @Prop({ required: true, type: SchemaTypes.ObjectId, default: 0 })
+  @Prop({ required: true, type: SchemaTypes.ObjectId })
   helpful!: string[];
 
-  @Prop({ required: true })
+  @Prop({ required: true, default: 0 })
   countHelpFul!: number;
 
   @Prop({ required: true, enum: Object.values(Role), default: Role.READER })

--- a/src/review/models/review.repository.ts
+++ b/src/review/models/review.repository.ts
@@ -1,0 +1,13 @@
+import { Model } from "mongoose";
+import { InjectModel } from "@nestjs/mongoose";
+import { Injectable } from "@nestjs/common";
+
+import { EntityRepository } from "@db/entity.repository";
+import { ReviewDocument, ReviewEntity } from "./review.entity";
+
+@Injectable()
+export class ReviewRepository extends EntityRepository<ReviewDocument> {
+  constructor(@InjectModel(ReviewEntity.name) reviewModel: Model<ReviewDocument>) {
+    super(reviewModel);
+  }
+}

--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -1,0 +1,48 @@
+import { ApiBody, ApiTags } from "@nestjs/swagger";
+import { Controller, Get, Post, Body, Patch, Param, Delete } from "@nestjs/common";
+
+import { ReviewService } from "./review.service";
+import { CreateReviewDto } from "./dto/create-review.dto";
+import { UpdateReviewDto } from "./dto/update-review.dto";
+
+const CONTROLLER_NAME = "reviews";
+
+@ApiTags(CONTROLLER_NAME)
+@Controller({ version: "1", path: CONTROLLER_NAME })
+export class ReviewController {
+  constructor(private readonly reviewService: ReviewService) {}
+
+  @ApiBody({ type: CreateReviewDto })
+  @Post(":userId/create/:bookId")
+  create(
+    @Param("userId") userId: string,
+    @Param("bookId") bookId: string,
+    @Body() createReviewDto: CreateReviewDto
+  ) {
+    return this.reviewService.create(userId, bookId, createReviewDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.reviewService.findAll();
+  }
+
+  @Get(":id")
+  findOne(@Param("id") id: string) {
+    return this.reviewService.findOne(id);
+  }
+
+  @Patch(":userId/update/:reviewId")
+  update(
+    @Param("userId") userId: string,
+    @Param("reviewId") reviewId: string,
+    @Body() updateReviewDto: UpdateReviewDto
+  ) {
+    return this.reviewService.update(userId, reviewId, updateReviewDto);
+  }
+
+  @Delete(":userId/delete/:reviewId")
+  remove(@Param("userId") userId: string, @Param("reviewId") reviewId: string) {
+    return this.reviewService.remove(userId, reviewId);
+  }
+}

--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -1,4 +1,11 @@
-import { ApiBody, ApiTags } from "@nestjs/swagger";
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiTags,
+} from "@nestjs/swagger";
 import {
   Controller,
   Get,
@@ -11,7 +18,7 @@ import {
 } from "@nestjs/common";
 import { UseRoles } from "@/auth/decorators/role.decorator";
 import { Role } from "@/auth/role.enum";
-import { JwtAuthGuard } from "@/auth/guards";
+import { JwtAuthGuard, RolesGuard } from "@/auth/guards";
 
 import { ReviewService } from "./review.service";
 import { CreateReviewDto } from "./dto/create-review.dto";
@@ -20,12 +27,16 @@ import { UpdateReviewDto } from "./dto/update-review.dto";
 const CONTROLLER_NAME = "reviews";
 
 @ApiTags(CONTROLLER_NAME)
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
 @Controller({ version: "1", path: CONTROLLER_NAME })
 export class ReviewController {
   constructor(private readonly reviewService: ReviewService) {}
 
   @ApiBody({ type: CreateReviewDto })
+  @ApiOkResponse({ description: "The record has been successfully created." })
+  @ApiNotFoundResponse({ description: "The record was not found." })
+  @ApiBadRequestResponse({ description: "The record has failed validation." })
+  @ApiForbiddenResponse({ description: "Forbidden!" })
   @Post(":userId/create/:bookId")
   create(
     @Param("userId") userId: string,
@@ -35,22 +46,38 @@ export class ReviewController {
     return this.reviewService.create(userId, bookId, createReviewDto);
   }
 
+  @ApiOkResponse({ description: "The record has been successfully returned." })
+  @ApiNotFoundResponse({ description: "The record was not found." })
+  @ApiBadRequestResponse({ description: "The record has failed validation." })
+  @ApiForbiddenResponse({ description: "Forbidden!" })
   @Get()
   @UseRoles(Role.ADMIN, Role.SUPER_ADMIN)
   findAll() {
     return this.reviewService.findAll();
   }
 
+  @ApiOkResponse({ description: "The record has been successfully returned." })
+  @ApiNotFoundResponse({ description: "The record was not found." })
+  @ApiBadRequestResponse({ description: "The record has failed validation." })
+  @ApiForbiddenResponse({ description: "Forbidden!" })
   @Get(":reviewId")
   findOne(@Param("reviewId") id: string) {
     return this.reviewService.findOne(id);
   }
 
+  @ApiOkResponse({ description: "The record has been successfully returned." })
+  @ApiNotFoundResponse({ description: "The record was not found." })
+  @ApiBadRequestResponse({ description: "The record has failed validation." })
+  @ApiForbiddenResponse({ description: "Forbidden!" })
   @Get("/book/:bookId")
   findAllBookReviews(@Param("bookId") bookId: string) {
     return this.reviewService.findAllBookReviews(bookId);
   }
 
+  @ApiOkResponse({ description: "The record has been successfully updated." })
+  @ApiNotFoundResponse({ description: "The record was not found." })
+  @ApiBadRequestResponse({ description: "The record has failed validation." })
+  @ApiForbiddenResponse({ description: "Forbidden!" })
   @Patch(":userId/update-review/:reviewId")
   updateReview(
     @Param("userId") userId: string,
@@ -60,11 +87,19 @@ export class ReviewController {
     return this.reviewService.updateReview(userId, reviewId, updateReviewDto);
   }
 
+  @ApiOkResponse({ description: "The record has been successfully updated." })
+  @ApiNotFoundResponse({ description: "The record was not found." })
+  @ApiBadRequestResponse({ description: "The record has failed validation." })
+  @ApiForbiddenResponse({ description: "Forbidden!" })
   @Patch(":userId/update-helpful/:reviewId")
   updateHelpful(@Param("userId") userId: string, @Param("reviewId") reviewId: string) {
     return this.reviewService.updateHelpful(userId, reviewId);
   }
 
+  @ApiOkResponse({ description: "The record has been successfully removed." })
+  @ApiNotFoundResponse({ description: "The record was not found." })
+  @ApiBadRequestResponse({ description: "The record has failed validation." })
+  @ApiForbiddenResponse({ description: "Forbidden!" })
   @Delete(":userId/delete/:reviewId/:bookId")
   remove(
     @Param("userId") userId: string,

--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -32,13 +32,18 @@ export class ReviewController {
     return this.reviewService.findOne(id);
   }
 
-  @Patch(":userId/update/:reviewId")
-  update(
+  @Patch(":userId/update-review/:reviewId")
+  updateReview(
     @Param("userId") userId: string,
     @Param("reviewId") reviewId: string,
     @Body() updateReviewDto: UpdateReviewDto
   ) {
-    return this.reviewService.update(userId, reviewId, updateReviewDto);
+    return this.reviewService.updateReview(userId, reviewId, updateReviewDto);
+  }
+
+  @Patch(":userId/update-helpful/:reviewId")
+  updateHelpful(@Param("userId") userId: string, @Param("reviewId") reviewId: string) {
+    return this.reviewService.updateHelpful(userId, reviewId);
   }
 
   @Delete(":userId/delete/:reviewId")

--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -1,5 +1,17 @@
 import { ApiBody, ApiTags } from "@nestjs/swagger";
-import { Controller, Get, Post, Body, Patch, Param, Delete } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+} from "@nestjs/common";
+import { UseRoles } from "@/auth/decorators/role.decorator";
+import { Role } from "@/auth/role.enum";
+import { JwtAuthGuard } from "@/auth/guards";
 
 import { ReviewService } from "./review.service";
 import { CreateReviewDto } from "./dto/create-review.dto";
@@ -8,6 +20,7 @@ import { UpdateReviewDto } from "./dto/update-review.dto";
 const CONTROLLER_NAME = "reviews";
 
 @ApiTags(CONTROLLER_NAME)
+@UseGuards(JwtAuthGuard)
 @Controller({ version: "1", path: CONTROLLER_NAME })
 export class ReviewController {
   constructor(private readonly reviewService: ReviewService) {}
@@ -23,13 +36,19 @@ export class ReviewController {
   }
 
   @Get()
+  @UseRoles(Role.ADMIN, Role.SUPER_ADMIN)
   findAll() {
     return this.reviewService.findAll();
   }
 
-  @Get(":id")
-  findOne(@Param("id") id: string) {
+  @Get(":reviewId")
+  findOne(@Param("reviewId") id: string) {
     return this.reviewService.findOne(id);
+  }
+
+  @Get("/book/:bookId")
+  findAllBookReviews(@Param("bookId") bookId: string) {
+    return this.reviewService.findAllBookReviews(bookId);
   }
 
   @Patch(":userId/update-review/:reviewId")
@@ -46,8 +65,12 @@ export class ReviewController {
     return this.reviewService.updateHelpful(userId, reviewId);
   }
 
-  @Delete(":userId/delete/:reviewId")
-  remove(@Param("userId") userId: string, @Param("reviewId") reviewId: string) {
-    return this.reviewService.remove(userId, reviewId);
+  @Delete(":userId/delete/:reviewId/:bookId")
+  remove(
+    @Param("userId") userId: string,
+    @Param("reviewId") reviewId: string,
+    @Param("bookId") bookId: string
+  ) {
+    return this.reviewService.remove(userId, reviewId, bookId);
   }
 }

--- a/src/review/review.module.ts
+++ b/src/review/review.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+
+import { ReviewRepository } from "./models/review.repository";
+import { ReviewService } from "./review.service";
+import { ReviewController } from "./review.controller";
+import { ReviewEntity, ReviewEntitySchema } from "./models/review.entity";
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: ReviewEntity.name, schema: ReviewEntitySchema }]),
+  ],
+  controllers: [ReviewController],
+  providers: [ReviewService, ReviewRepository],
+})
+export class ReviewModule {}

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+
+import { CreateReviewDto } from "./dto/create-review.dto";
+import { ReviewRepository } from "./models/review.repository";
+import { UpdateReviewDto } from "./dto/update-review.dto";
+
+@Injectable()
+export class ReviewService {
+  constructor(private readonly reviewRepository: ReviewRepository) {}
+
+  async create(_userId: string, _bookId: string, r: CreateReviewDto) {
+    //Todo?: User can only create one review per book
+    //Todo?: User can't comment to its own book
+
+    const newReviewRecord = await this.reviewRepository.create({ ...r });
+
+    Logger.log(`Create new review: ${newReviewRecord}`, ReviewService.name);
+
+    const { __v, ...newReviewRecordWithoutVersion } = newReviewRecord.toObject();
+
+    return newReviewRecordWithoutVersion;
+  }
+
+  public async findAll() {
+    const reviewRecords = await this.reviewRepository.find();
+    if (!reviewRecords) throw new NotFoundException("No review records found!");
+    return reviewRecords;
+  }
+
+  async findOne(id: string) {
+    const reviewRecord = await this.reviewRepository.findById(id);
+    if (!reviewRecord) throw new NotFoundException("No review record found!");
+
+    return reviewRecord;
+  }
+
+  async update(userId: string, reviewId: string, updateReviewDto: UpdateReviewDto) {
+    const reviewRecord = await this.reviewRepository.findById(reviewId);
+
+    if (!reviewRecord) throw new NotFoundException("No user record found!");
+
+    if (reviewRecord.user !== userId) throw new NotFoundException("Incorrect user");
+
+    const updateReviewObject = {
+      helpful: updateReviewDto.helpful || reviewRecord.helpful,
+      countHelpful: updateReviewDto.countHelpful || reviewRecord.countHelpFul,
+    };
+
+    return this.reviewRepository.findByIdAndUpdate(reviewId, updateReviewObject);
+  }
+
+  async remove(userId: string, reviewId: string) {
+    const reviewRecord = await this.reviewRepository.findById(reviewId);
+
+    if (!reviewRecord) throw new NotFoundException("No review record found!");
+    if (reviewRecord.user !== userId)
+      throw new NotFoundException("This review doesn't belong to you!");
+
+    return {
+      deleted: await this.reviewRepository.deleteOne({ _id: reviewId }),
+    };
+  }
+}

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -55,6 +55,13 @@ export class ReviewService {
     return reviewRecord;
   }
 
+  async findAllBookReviews(bookId: string) {
+    const bookRecord = await this.bookRepository.findById(bookId);
+    if (!bookRecord) throw new NotFoundException("No book record found!");
+
+    return bookRecord.reviews;
+  }
+
   async updateReview(userId: string, reviewId: string, updateReviewDto: UpdateReviewDto) {
     const reviewRecord = await this.reviewRepository.findById(reviewId);
 
@@ -72,7 +79,6 @@ export class ReviewService {
   async updateHelpful(userId: string, reviewId: string) {
     const reviewRecord = await this.reviewRepository.findById(reviewId);
     if (!reviewRecord) throw new NotFoundException("No Review record found!");
-    //Todo?: Users need to be authenticated to count as helpful
 
     if (reviewRecord.helpful.find((id) => id === userId)) {
       const filteredArray = reviewRecord.helpful.filter((id) => id !== userId);

--- a/src/review/role.enum.ts
+++ b/src/review/role.enum.ts
@@ -1,0 +1,6 @@
+export enum Role {
+  READER = "1",
+  AUTHOR = "2",
+}
+
+export type RoleType = `${Role}`;


### PR DESCRIPTION
### Commit resume

- Added the new auth controller, as well, service for admins. 

- Also, added the `username` field in the auth `create-user-dto`, plus the corresponding changes to the services that use this DTO.